### PR TITLE
prevent NailStats consumers from reading stale values

### DIFF
--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NailStats.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NailStats.java
@@ -68,7 +68,9 @@ public class NailStats implements Cloneable {
 	 * @return the number of times this nail has been run.
 	 */
 	public long getRunCount() {
-		return (runCounter);
+		synchronized (lock) {
+			return (runCounter);	
+		}
 	}
 	
 	/**
@@ -76,7 +78,9 @@ public class NailStats implements Cloneable {
 	 * @return the number of sessions currently running this nail. 
 	 */
 	public long getRefCount() {
-		return (refCounter);
+		synchronized (lock) {
+			return (refCounter);
+		}
 	}
 	
 	/**


### PR DESCRIPTION
In a multi-processor environment, synchronization must be performed for reads just as it is required for writes.

Hope contributions are appreciated!

Thanks - Victor
