### PR TITLE
Forward isatty on *nix as part of the environment

### DIFF
--- a/nailgun-client/ng.c
+++ b/nailgun-client/ng.c
@@ -100,6 +100,8 @@
 
 #define HEARTBEAT_TIMEOUT_MILLIS 500
 
+#define NAILGUN_TTY_FORMAT "NAILGUN_TTY_%d=%d"
+
 /*
    the following is required to compile for hp-ux
    originally posted at http://jira.codehaus.org/browse/JRUBY-2346
@@ -758,6 +760,15 @@ int main(int argc, char *argv[], char *env[]) {
   /* now send environment */  
   sendText(CHUNKTYPE_ENV, NAILGUN_FILESEPARATOR);
   sendText(CHUNKTYPE_ENV, NAILGUN_PATHSEPARATOR);
+#ifndef WIN32
+  /* notify isatty for standard pipes */
+  char buf[] = NAILGUN_TTY_FORMAT;
+  for(i = 0; i < 3; i++) {
+    sprintf(buf, NAILGUN_TTY_FORMAT, i, isatty(i));
+    sendText(CHUNKTYPE_ENV, buf);
+  }
+#endif
+  /* forward the client process environment */
   for(i = 0; env[i]; ++i) {
     sendText(CHUNKTYPE_ENV, env[i]);
   }


### PR DESCRIPTION
In order to allow to programatically determine if a command can output Ansi color sequences to a standard stream, it's usually needed to know if the pipe is actually attached to a terminal or is being redirected.

The proposed changes forward the result of `isatty` for the standard streams (stdin, stdout and stderr) as part of the environment setup. This way the command running in the server can use them in its algorithm to enable coloured output.

Windows support should be possible but not by using `isatty` according to [StackOverflow](http://stackoverflow.com/a/3650507), it's not clear though the benefit of enabling this for windows, since the default terminals do not support Ansi sequences AFAIK.

This is what the new environment variables look like:

```
$ ng foo > /tmp/stdout.txt
NAILGUN_TTY_0=1
NAILGUN_TTY_1=0
NAILGUN_TTY_2=1
```
