### PR TITLE
Allow java classes to close stdout/stderr

### DIFF
--- a/nailgun-examples/src/main/java/com/martiansoftware/nailgun/examples/Exit.java
+++ b/nailgun-examples/src/main/java/com/martiansoftware/nailgun/examples/Exit.java
@@ -27,6 +27,9 @@ public class Exit {
 	       		exitCode = Integer.parseInt(args[0]);
 	       	} catch (Exception e) {}
        	}
+		// Close stdout to test the exit code is returned properly
+		// even in such case
+		System.out.close();
        	System.exit(exitCode);
       }
 	


### PR DESCRIPTION
When the client calls a class, where either stdout or stderr is closed
the socket connection to the client is closed and no further data is
sent. This includes data transmitted over the other stream and exit
codes.

fixes #23
